### PR TITLE
Fix mention strings to be pronounced as indicated

### DIFF
--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -696,7 +696,7 @@ export class Zundacord {
             return
         }
 
-        const readableStr = getReadableString(msg.content)
+        const readableStr = getReadableString(msg.cleanContent)
         log.debug(ctx, `readableStr = ${readableStr}`)
 
         player.queueMessage({


### PR DESCRIPTION
Resolve #30
I have confirmed the following strings work

- `@username`
- `@role`
- `#channel`
