### PR TITLE
Skip empty string

### DIFF
--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -698,7 +698,10 @@ export class Zundacord {
 
         const readableStr = getReadableString(msg.content)
         log.debug(ctx, `readableStr = ${readableStr}`)
-
+        if (!readableStr) {
+            log.debug(ctx, `Skip reading as it is empty text`)
+            return
+        }
         player.queueMessage({
             styleId: styleId,
             message: readableStr,


### PR DESCRIPTION
Resolve #39
Empty characters are not queued to be read out loud and the function exits.