### PR TITLE
disconnect automatically when no user in voice

### DIFF
--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -29,7 +29,6 @@ export class Zundacord {
     private readonly guildPlayers: Map<string, Player> = new Map()
 
     private applicationId: string = ""
-    private timeoutId: NodeJS.Timeout | undefined = undefined
 
     constructor(token: string, apiEndpoint: string) {
         this.token = token
@@ -147,8 +146,7 @@ export class Zundacord {
         }
 
         log.debug("zundamon is alone ;;")
-        clearTimeout(this.timeoutId)
-        this.timeoutId = setTimeout(async () => {
+        setTimeout(async () => {
             if(await this.checkAloneInVoiceChannel(cachedChannel)) {
                 getVoiceConnection(oldState.guild.id)?.disconnect();
             }

--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -134,8 +134,12 @@ export class Zundacord {
 
     onVoiceStateUpdate(oldState: VoiceState, newState: VoiceState)
     {
-        const cid = getVoiceConnection(oldState.guild.id)?.joinConfig.channelId ?? ""
-        const channel = oldState.guild.channels.cache.find(c => c.id === cid)
+        const vc = getVoiceConnection(oldState.guild.id)
+        if(!vc) {
+            return
+        }
+
+        const channel = oldState.guild.channels.cache.find(c => c.id === vc.joinConfig.channelId)
         if(channel === undefined || !channel.isVoiceBased()) {
             return
         }
@@ -144,7 +148,7 @@ export class Zundacord {
             log.debug("zundamon is alone ;;")
             setTimeout(() => {
                 if(channel.members.size === 1 && channel.members.has(this.applicationId)) {
-                    getVoiceConnection(oldState.guild.id)?.disconnect();
+                    vc.disconnect();
                 }
             }, TIMEOUT)
         }

--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -132,7 +132,7 @@ export class Zundacord {
         this.queueMessage(msg, memberConfig?.voiceStyleId)
     }
 
-    async onVoiceStateUpdate(oldState: VoiceState, newState: VoiceState)
+    onVoiceStateUpdate(oldState: VoiceState, newState: VoiceState)
     {
         const cid = getVoiceConnection(oldState.guild.id)?.joinConfig.channelId ?? ""
         const channel = oldState.guild.channels.cache.find(c => c.id === cid)
@@ -140,17 +140,14 @@ export class Zundacord {
             return
         }
 
-        if(channel.members.size !== 1 || !channel.members.has(this.applicationId)) {
-            log.debug("zundamon is not alone")
-            return
+        if(channel.members.size === 1 && channel.members.has(this.applicationId)) {
+            log.debug("zundamon is alone ;;")
+            setTimeout(() => {
+                if(channel.members.size === 1 && channel.members.has(this.applicationId)) {
+                    getVoiceConnection(oldState.guild.id)?.disconnect();
+                }
+            }, TIMEOUT)
         }
-
-        log.debug("zundamon is alone ;;")
-        setTimeout(async () => {
-            if(channel.members.size === 1 && channel.members.has(this.applicationId)) {
-                getVoiceConnection(oldState.guild.id)?.disconnect();
-            }
-        }, TIMEOUT)
     }
 
     async slashVoice(interaction: CommandInteraction<"cached">) {

--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -135,32 +135,18 @@ export class Zundacord {
 
     async onVoiceStateUpdate(oldState: VoiceState, newState: VoiceState)
     {
-        //someone joined voice
-        if(!oldState.channelId && newState.channelId) {
-            log.debug("someone joined voice")
-            return
-        }
-
-        //zundamon left voice
-        const clientId = this.client.user?.id ?? ""
-        if(newState.id === clientId) {
-            log.debug("zundamon left voice")
-            return
-        }
-
-        const cachedChannel = oldState.guild.channels.cache.find(c => c.id === oldState.channelId)
+        const cid = getVoiceConnection(oldState.guild.id)?.joinConfig.channelId ?? ""
+        const cachedChannel = oldState.guild.channels.cache.find(c => c.id === cid)
         if(cachedChannel === undefined) {
             return
         }
 
-        //someone left voice where zundamon is not
-        if(await this.checkAloneInVoiceChannel(cachedChannel) === false) {
-            log.debug("someone left voice where zundamon is not")
+        if(!await this.checkAloneInVoiceChannel(cachedChannel)) {
+            log.debug("zundamon is not alone")
             return
         }
 
-        //someone left voice where zundamon is
-        log.debug("someone left voice where zundamon is")
+        log.debug("zundamon is alone ;;")
         clearTimeout(this.timeoutId)
         this.timeoutId = setTimeout(async () => {
             if(await this.checkAloneInVoiceChannel(cachedChannel)) {

--- a/src/zundacord/app.ts
+++ b/src/zundacord/app.ts
@@ -135,19 +135,19 @@ export class Zundacord {
     async onVoiceStateUpdate(oldState: VoiceState, newState: VoiceState)
     {
         const cid = getVoiceConnection(oldState.guild.id)?.joinConfig.channelId ?? ""
-        const cachedChannel = oldState.guild.channels.cache.find(c => c.id === cid)
-        if(cachedChannel === undefined) {
+        const channel = oldState.guild.channels.cache.find(c => c.id === cid)
+        if(channel === undefined || !channel.isVoiceBased()) {
             return
         }
 
-        if(!await this.checkAloneInVoiceChannel(cachedChannel)) {
+        if(channel.members.size !== 1 || !channel.members.has(this.applicationId)) {
             log.debug("zundamon is not alone")
             return
         }
 
         log.debug("zundamon is alone ;;")
         setTimeout(async () => {
-            if(await this.checkAloneInVoiceChannel(cachedChannel)) {
+            if(channel.members.size === 1 && channel.members.has(this.applicationId)) {
                 getVoiceConnection(oldState.guild.id)?.disconnect();
             }
         }, TIMEOUT)
@@ -756,12 +756,5 @@ export class Zundacord {
             styleId: styleId,
             message: readableStr,
         })
-    }
-
-    async checkAloneInVoiceChannel(channel: GuildBasedChannel) {
-        if(!channel.isVoiceBased()) return false;
-
-        const members = (await channel.fetch(true) as VoiceChannel).members;
-        return members.size === 1 && members.has(this.applicationId);
     }
 }

--- a/src/zundacord/player.ts
+++ b/src/zundacord/player.ts
@@ -37,14 +37,12 @@ export class Player {
 
     autoDisconnect(vc: VoiceConnection, channel: VoiceBasedChannel, appId: string, timeout: number = 5000) {
         clearTimeout(this.disconnectTimeoutId)
-        if(channel.members.size === 1 && channel.members.has(appId)) {
-            this.disconnectTimeoutId = setTimeout(() => {
-                if(channel.members.size === 1 && channel.members.has(appId)) {
-                    vc.disconnect();
-                }
-                this.disconnectTimeoutId = undefined
-            }, timeout)
-        }
+        this.disconnectTimeoutId = setTimeout(() => {
+            if(channel.members.size === 1 && channel.members.has(appId)) {
+                vc.disconnect();
+            }
+            this.disconnectTimeoutId = undefined
+        }, timeout)
     }
 
     skipCurrentMessage() {


### PR DESCRIPTION
resolve #21 

**未対応**
ずんだもんをvcから切断すると[Reconnect処理](https://github.com/aria-music/zundacord/blob/main/src/zundacord/app.ts#L263)がはしる。
この時に`/join`すると、ずんだもんがvcにいないのにAlready joined!と表示される。