### PR TITLE
複数URLを全て「リンク」に置換＋改行コードを空白に置換

### DIFF
--- a/src/zundacord/utils.ts
+++ b/src/zundacord/utils.ts
@@ -1,7 +1,7 @@
 // remove emojis, Discord Emoji escapes from string
 export function getReadableString(str: string): string {
     return str
-        .replace(/\r?\n|\r/g, " ")
+        .replace(/\r?\n/g, " ")
         .replace(/https?:\/\/[^\s]+/g, "リンク") // http(s) url
         .replace(/<a?:[^:]+:[0-9]+>/g, "") // discord emoji & Animated emoji
         .replace(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, "") // unicode emoji

--- a/src/zundacord/utils.ts
+++ b/src/zundacord/utils.ts
@@ -1,7 +1,7 @@
 // remove emojis, Discord Emoji escapes from string
 export function getReadableString(str: string): string {
     return str
-        .replace(/https?:\/\/[^\s]+/, "リンク") // http(s) url
+        .replace(/https?:\/\/[^\s]+/g, "リンク") // http(s) url
         .replace(/<a?:[^:]+:[0-9]+>/g, "") // discord emoji & Animated emoji
         .replace(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, "") // unicode emoji
         .trim()

--- a/src/zundacord/utils.ts
+++ b/src/zundacord/utils.ts
@@ -1,6 +1,7 @@
 // remove emojis, Discord Emoji escapes from string
 export function getReadableString(str: string): string {
     return str
+        .replace(/\r?\n|\r/g, " ")
         .replace(/https?:\/\/[^\s]+/g, "リンク") // http(s) url
         .replace(/<a?:[^:]+:[0-9]+>/g, "") // discord emoji & Animated emoji
         .replace(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, "") // unicode emoji

--- a/tests/zundacord/utils.test.ts
+++ b/tests/zundacord/utils.test.ts
@@ -13,7 +13,10 @@ test.each([
     ["プロロのキレ良し？", "プロロのキレ良し？"],
     ["プロロのキレ良し!?", "プロロのキレ良し!?"],
     ["Visit https://sarisia.cc", "Visit リンク"],
-    ["Visit http://sarisia.cc", "Visit リンク"]
+    ["Visit http://sarisia.cc", "Visit リンク"],
+    ["Visit http://sarisia.cc http://sarisia.cc", "Visit リンク リンク"],
+    ["Visit http://sarisia.cc\nhttp://sarisia.cc", "Visit リンク リンク"],
+    ["This\r\nis\rvery\nfast", "This is very fast"],
 ])("getReadableString(%s)", (str, expected) => {
     expect(getReadableString(str)).toBe(expected)
 })

--- a/tests/zundacord/utils.test.ts
+++ b/tests/zundacord/utils.test.ts
@@ -16,7 +16,7 @@ test.each([
     ["Visit http://sarisia.cc", "Visit リンク"],
     ["Visit http://sarisia.cc http://sarisia.cc", "Visit リンク リンク"],
     ["Visit http://sarisia.cc\nhttp://sarisia.cc", "Visit リンク リンク"],
-    ["This\r\nis\rvery\nfast", "This is very fast"],
+    ["This\r\nis very\nfast", "This is very fast"],
 ])("getReadableString(%s)", (str, expected) => {
     expect(getReadableString(str)).toBe(expected)
 })


### PR DESCRIPTION
resolve #59 

以下の置換を行った文章をずんだもんが読み上げるようにした
+改行コードを空白に置換
+URLは全て「リンク」に置換